### PR TITLE
fix typo related to the word "console"

### DIFF
--- a/resources/lang/en/errors.php
+++ b/resources/lang/en/errors.php
@@ -22,7 +22,7 @@ return [
 
     'pretendo' => [
         'title' => 'Authentication Error',
-        'desc' => ':name can\'t authenticate your conssole as you may be using Pretendo Network to access :name. Please switch back to Nintendo Network and try again.',
+        'desc' => ':name can\'t authenticate your console as you may be using Pretendo Network to access :name. Please switch back to Nintendo Network and try again.',
         'button' => 'Close',
     ],
 ];


### PR DESCRIPTION
There was a typo. This should be a quick and clean pull that fixes that.